### PR TITLE
December 2020 updates for SharePoint 2010-2019 and OOS

### DIFF
--- a/Scripts/AutoSPSourceBuilder.xml
+++ b/Scripts/AutoSPSourceBuilder.xml
@@ -116,7 +116,7 @@
             <CumulativeUpdate Name="September 2020" Build="14.0.7260.5000" Url="https://download.microsoft.com/download/1/6/5/165c53de-aa1f-4e9d-888e-5fb6aadf47a2/ubersrv2010-kb4486662-fullfile-x64-glb.exe" ExpandedFile="ubersrv2010-kb4486662-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="October 2020" Build="14.0.7261.5000" Url="https://download.microsoft.com/download/8/e/8/8e88e522-416a-483f-828e-5c2ca5a6597e/ubersrv2010-kb4486705-fullfile-x64-glb.exe" ExpandedFile="ubersrv2010-kb4486705-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="November 2020" Build="14.0.7262.5000" Url="https://download.microsoft.com/download/e/7/3/e736eeaf-7b0e-474e-88c8-f05e4b693369/ubersrv2010-kb4486741-fullfile-x64-glb.exe" ExpandedFile="ubersrv2010-kb4486741-fullfile-x64-glb.exe" />
-            <CumulativeUpdate Name="December 2020" Build="14.0.7263.5000" Url="https://download.microsoft.com/download/0/4/b/04bc54f3-1bd3-4498-80ee-d176fe2faa05/ubersrv2010-kb4493146-fullfile-x64-glb.exe " ExpandedFile="ubersrv2010-kb4493146-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="December 2020" Build="14.0.7263.5000" Url="https://download.microsoft.com/download/0/4/b/04bc54f3-1bd3-4498-80ee-d176fe2faa05/ubersrv2010-kb4493146-fullfile-x64-glb.exe" ExpandedFile="ubersrv2010-kb4493146-fullfile-x64-glb.exe" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="ar" Url="http://download.microsoft.com/download/A/6/C/A6C2FAE9-58A4-410D-81E0-682E8CBF3D18/ServerLanguagePack.exe">
@@ -1311,8 +1311,8 @@
             <CumulativeUpdate Name="November 2020" Build="16.0.5083.1000" Url="https://download.microsoft.com/download/b/1/2/b1230649-565d-4495-8040-c1c531ac98e9/sts2016-kb4486717-fullfile-x64-glb.exe" ExpandedFile="sts2016-kb4486717-fullfile-x64-glb.exe" />
             <!--There was no language-dependent fix released for SharePoint 2016 in November 2020, so the link below is actually for the last-released language-dependent fix (October 2020)-->
             <CumulativeUpdate Name="November 2020" Build="16.0.5083.1000" Url="https://download.microsoft.com/download/4/0/7/407093c8-d09e-4fae-9ee9-d0dd979efd63/wssloc2016-kb4486681-fullfile-x64-glb.exe" ExpandedFile="wssloc2016-kb4486681-fullfile-x64-glb.exe" />
-            <CumulativeUpdate Name="December 2020" Build="16.0.5095.1000" Url="https://download.microsoft.com/download/4/d/9/4d94a4ca-e171-4a89-ad44-937179183986/wssloc2016-kb4486721-fullfile-x64-glb.exe" ExpandedFile="wssloc2016-kb4486721-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="December 2020" Build="16.0.5095.1000" Url="https://download.microsoft.com/download/d/4/7/d4785d45-0f73-4e94-8522-136fa1fee390/sts2016-kb4486753-fullfile-x64-glb.exe" ExpandedFile="sts2016-kb4486753-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="December 2020" Build="16.0.5095.1000" Url="https://download.microsoft.com/download/4/d/9/4d94a4ca-e171-4a89-ad44-937179183986/wssloc2016-kb4486721-fullfile-x64-glb.exe" ExpandedFile="wssloc2016-kb4486721-fullfile-x64-glb.exe" />
         </CumulativeUpdates>
         <LanguagePacks>
           <LanguagePack Name="az-Latn-AZ" Url="https://download.microsoft.com/download/4/1/7/41789DDA-ABDD-45D2-AAB9-79025E69166B/serverlanguagepack.exe">
@@ -2043,6 +2043,7 @@
             <CumulativeUpdate Name="September 2020" Build="16.0.10366.12106" Url="https://download.microsoft.com/download/1/5/f/15f86f27-ac29-4b37-93e7-f95f2f42efe9/wacserver2019-kb4484503-fullfile-x64-glb.exe" ExpandedFile="wacserver2019-kb4484503-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="October 2020" Build="16.0.10367.20000" Url="https://download.microsoft.com/download/1/d/c/1dcd08ca-55a9-4cb7-9c93-165a0fce1d1b/wacserver2019-kb4486674-fullfile-x64-glb.exe" ExpandedFile="wacserver2019-kb4486674-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="November 2020" Build="16.0.10368.20022" Url="https://download.microsoft.com/download/2/6/9/2690f028-10ab-420a-be18-5e787288b7b7/wacserver2019-kb4486713-fullfile-x64-glb.exe" ExpandedFile="wacserver2019-kb4486713-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="December 2020" Build="16.0.10369.20000" Url="https://download.microsoft.com/download/8/4/a/84ac1fc0-2f82-4490-bacf-dd33392309c4/wacserver2019-kb4486750-fullfile-x64-glb.exe" ExpandedFile="wacserver2019-kb4486750-fullfile-x64-glb.exe" /> 
         </CumulativeUpdates>
       <LanguagePacks>
         <LanguagePack Name="az-Latn-AZ" Url="https://download.microsoft.com/download/A/0/3/A03B732F-512B-4D29-A2FD-49873FEA60C3/wacserverlanguagepack.exe">


### PR DESCRIPTION
- Added OOS (OfficeOnlineServer2019) Update
- Removed some spaces
- Reordered SP2016 CU files: language independed (sts) -> language depended (wssloc)

@brianlala 
Sorry, here's a new, clean pull request.