### PR TITLE
February 2022 udpates for SharePoint 2013-2019, SharePoint SE and OOS

### DIFF
--- a/Scripts/AutoSPSourceBuilder.xml
+++ b/Scripts/AutoSPSourceBuilder.xml
@@ -719,6 +719,9 @@
             <CumulativeUpdate Name="January 2022" Build="15.0.5415.1000" Url="https://download.microsoft.com/download/b/5/a/b5accafa-2616-4437-afd0-2c741f5b3d49/ubersrv2013-kb5002126-fullfile-x64-glb.exe" ExpandedFile="ubersrv2013-kb5002126-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="January 2022" Build="15.0.5415.1000" Url="https://download.microsoft.com/download/b/5/a/b5accafa-2616-4437-afd0-2c741f5b3d49/ubersrv_1.cab" ExpandedFile="ubersrv_1.cab" />
             <CumulativeUpdate Name="January 2022" Build="15.0.5415.1000" Url="https://download.microsoft.com/download/b/5/a/b5accafa-2616-4437-afd0-2c741f5b3d49/ubersrv_2.cab" ExpandedFile="ubersrv_2.cab" />
+            <CumulativeUpdate Name="February 2022" Build="15.0.5423.1000" Url="https://download.microsoft.com/download/0/8/3/083a5a59-c3a9-4b7c-b143-9dbc4e667be7/ubersrv2013-kb5002154-fullfile-x64-glb.exe" ExpandedFile="ubersrv2013-kb5002154-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="February 2022" Build="15.0.5423.1000" Url="https://download.microsoft.com/download/0/8/3/083a5a59-c3a9-4b7c-b143-9dbc4e667be7/ubersrv_1.cab" ExpandedFile="ubersrv_1.cab" />
+            <CumulativeUpdate Name="February 2022" Build="15.0.5423.1000" Url="https://download.microsoft.com/download/0/8/3/083a5a59-c3a9-4b7c-b143-9dbc4e667be7/ubersrv_2.cab" ExpandedFile="ubersrv_2.cab" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="pl-pl" Url="http://download.microsoft.com/download/3/3/3/3331D355-BBAA-4D86-A2AD-FEC7D45261FC/serverlanguagepack.img">
@@ -1013,6 +1016,7 @@
             <CumulativeUpdate Name="November 2021" Build="15.0.5397.1000" Url="https://download.microsoft.com/download/7/d/a/7daba04f-59dd-45fb-b063-86c595e2671c/wacserver2013-kb5002065-fullfile-x64-glb.exe" ExpandedFile="wacserver2013-kb5002065-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="December 2021" Build="15.0.5407.1000" Url="https://download.microsoft.com/download/c/3/9/c3926141-9a9f-49c3-8af8-38aed12648a4/wacserver2013-kb5002103-fullfile-x64-glb.exe" ExpandedFile="wacserver2013-kb5002103-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="January 2022" Build="15.0.5415.1000" Url="https://download.microsoft.com/download/1/6/5/1658e215-6260-4c0d-857d-ac87a138b232/wacserver2013-kb5002122-fullfile-x64-glb.exe" ExpandedFile="wacserver2013-kb5002122-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="February 2022" Build="15.0.5423.1000" Url="https://download.microsoft.com/download/6/2/3/62350400-a52c-4d2d-b431-b80f3e77b846/wacserver2013-kb5002149-fullfile-x64-glb.exe" ExpandedFile="wacserver2013-kb5002149-fullfile-x64-glb.exe" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="de-de" Url="http://download.microsoft.com/download/D/8/6/D8689A1C-A5FC-4279-A397-9CE9198C6FDB/wacserverlanguagepack.exe">
@@ -1257,9 +1261,12 @@
             <CumulativeUpdate Name="December 2021" Build="15.0.5407.1000" Url="https://download.microsoft.com/download/1/9/2/19255f1e-7f64-4570-8527-2b60664e85b0/ubersrvprj2013-kb5002067-fullfile-x64-glb.exe" ExpandedFile="ubersrvprj2013-kb5002067-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="December 2021" Build="15.0.5407.1000" Url="https://download.microsoft.com/download/1/9/2/19255f1e-7f64-4570-8527-2b60664e85b0/ubersrvprj_1.cab" ExpandedFile="ubersrvprj_1.cab" />
             <CumulativeUpdate Name="December 2021" Build="15.0.5407.1000" Url="https://download.microsoft.com/download/1/9/2/19255f1e-7f64-4570-8527-2b60664e85b0/ubersrvprj_2.cab" ExpandedFile="ubersrvprj_2.cab" />
-            <CumulativeUpdate Name="January 2021" Build="15.0.5415.1000" Url="https://download.microsoft.com/download/a/0/7/a0776e77-3ab0-4f00-b5b2-282f199bd33c/ubersrvprj2013-kb5002125-fullfile-x64-glb.exe" ExpandedFile="ubersrvprj2013-kb5002125-fullfile-x64-glb.exe" />
-            <CumulativeUpdate Name="January 2021" Build="15.0.5415.1000" Url="https://download.microsoft.com/download/a/0/7/a0776e77-3ab0-4f00-b5b2-282f199bd33c/ubersrvprj_1.cab" ExpandedFile="ubersrvprj_1.cab" />
-            <CumulativeUpdate Name="January 2021" Build="15.0.5415.1000" Url="https://download.microsoft.com/download/a/0/7/a0776e77-3ab0-4f00-b5b2-282f199bd33c/ubersrvprj_2.cab" ExpandedFile="ubersrvprj_2.cab" />
+            <CumulativeUpdate Name="January 2022" Build="15.0.5415.1000" Url="https://download.microsoft.com/download/a/0/7/a0776e77-3ab0-4f00-b5b2-282f199bd33c/ubersrvprj2013-kb5002125-fullfile-x64-glb.exe" ExpandedFile="ubersrvprj2013-kb5002125-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="January 2022" Build="15.0.5415.1000" Url="https://download.microsoft.com/download/a/0/7/a0776e77-3ab0-4f00-b5b2-282f199bd33c/ubersrvprj_1.cab" ExpandedFile="ubersrvprj_1.cab" />
+            <CumulativeUpdate Name="January 2022" Build="15.0.5415.1000" Url="https://download.microsoft.com/download/a/0/7/a0776e77-3ab0-4f00-b5b2-282f199bd33c/ubersrvprj_2.cab" ExpandedFile="ubersrvprj_2.cab" />
+            <CumulativeUpdate Name="February 2022" Build="15.0.5423.1000" Url="https://download.microsoft.com/download/2/0/7/207f8ab0-1c21-42be-8c4b-0c82ed2ef8da/ubersrvprj2013-kb5002152-fullfile-x64-glb.exe" ExpandedFile="ubersrvprj2013-kb5002152-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="February 2022" Build="15.0.5423.1000" Url="https://download.microsoft.com/download/2/0/7/207f8ab0-1c21-42be-8c4b-0c82ed2ef8da/ubersrvprj_1.cab" ExpandedFile="ubersrvprj_1.cab" />
+            <CumulativeUpdate Name="February 2022" Build="15.0.5423.1000" Url="https://download.microsoft.com/download/2/0/7/207f8ab0-1c21-42be-8c4b-0c82ed2ef8da/ubersrvprj_2.cab" ExpandedFile="ubersrvprj_2.cab" />
         </CumulativeUpdates>
     </Product>
     <Product Name="SP2016">
@@ -1439,6 +1446,9 @@
             <CumulativeUpdate Name="December 2021" Build="16.0.5254.1000" Url="https://download.microsoft.com/download/0/a/3/0a3beafc-65b0-4708-ada4-832e0cf99ecc/wssloc2016-kb5002059-fullfile-x64-glb.exe" ExpandedFile="wssloc2016-kb5002059-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="January 2022" Build="16.0.5266.1000" Url="https://download.microsoft.com/download/8/6/e/86e2b0b7-18be-44fa-9f86-7ba7a2f71721/sts2016-kb5002113-fullfile-x64-glb.exe" ExpandedFile="sts2016-kb5002113-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="January 2022" Build="16.0.5266.1000" Url="https://download.microsoft.com/download/c/d/c/cdc66551-193f-4786-843f-c37e522c5025/wssloc2016-kb5002118-fullfile-x64-glb.exe" ExpandedFile="wssloc2016-kb5002118-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="February 2022" Build="16.0.5278.1000" Url="https://download.microsoft.com/download/a/1/e/a1ef906b-df5a-4e42-8c96-fc7056a2d665/sts2016-kb5002136-fullfile-x64-glb.exe" ExpandedFile="sts2016-kb5002136-fullfile-x64-glb.exe" />
+            <!--There was no language-dependent fix released for SharePoint 2016 in February 2022, so the link below is actually for the last-released language-dependent fix (January 2022)-->
+            <CumulativeUpdate Name="February 2022" Build="16.0.5278.1000" Url="https://download.microsoft.com/download/c/d/c/cdc66551-193f-4786-843f-c37e522c5025/wssloc2016-kb5002118-fullfile-x64-glb.exe" ExpandedFile="wssloc2016-kb5002118-fullfile-x64-glb.exe" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="az-Latn-AZ" Url="https://download.microsoft.com/download/4/1/7/41789DDA-ABDD-45D2-AAB9-79025E69166B/serverlanguagepack.exe">
@@ -1966,6 +1976,8 @@
             <CumulativeUpdate Name="December 2021" Build="16.0.10381.20001" Url="https://download.microsoft.com/download/3/f/3/3f3437e8-7a62-455c-b878-86b71a11cb39/wssloc2019-kb5002061-fullfile-x64-glb.exe" ExpandedFile="wssloc2019-kb5002061-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="January 2022" Build="16.0.10382.20004" Url="https://download.microsoft.com/download/0/4/f/04fc4931-af4c-4011-9f48-2b23e479b3d4/sts2019-kb5002109-fullfile-x64-glb.exe" ExpandedFile="sts2019-kb5002109-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="January 2022" Build="16.0.10382.20004" Url="https://download.microsoft.com/download/5/9/f/59f0bcd8-5d08-489c-8027-4df9c7bfc692/wssloc2019-kb5002108-fullfile-x64-glb.exe" ExpandedFile="wssloc2019-kb5002108-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="February 2022" Build="16.0.10383.20001" Url="https://download.microsoft.com/download/3/8/2/382d77ab-f2b4-4197-9cb1-e0ec3e38aef3/sts2019-kb5002135-fullfile-x64-glb.exe" ExpandedFile="sts2019-kb5002135-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="February 2022" Build="16.0.10383.20001" Url="https://download.microsoft.com/download/c/0/8/c08a2f5f-8b80-4e42-ba5e-da2ee8c356bd/wssloc2019-kb5002134-fullfile-x64-glb.exe" ExpandedFile="wssloc2019-kb5002134-fullfile-x64-glb.exe" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="az-Latn-AZ" Url="https://download.microsoft.com/download/D/6/4/D64A6203-2BB1-43AA-9EA6-365EE5A37E2F/serverlanguagepack.exe">
@@ -2208,6 +2220,7 @@
             <CumulativeUpdate Name="November 2021" Build="16.0.10380.20000" Url="https://download.microsoft.com/download/9/f/2/9f2ac35e-e111-4bd6-af83-814b5062c62e/wacserver2019-kb5002053-fullfile-x64-glb.exe" ExpandedFile="wacserver2019-kb5002053-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="December 2021" Build="16.0.10381.20001" Url="https://download.microsoft.com/download/8/5/e/85e76ead-0b1e-434d-bb15-0d8ab36c3209/wacserver2019-kb5002097-fullfile-x64-glb.exe" ExpandedFile="wacserver2019-kb5002097-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="January 2022" Build="16.0.10382.20004" Url="https://download.microsoft.com/download/d/8/3/d83419f1-2fd4-4dd0-b671-a17511d9b274/wacserver2019-kb5002107-fullfile-x64-glb.exe" ExpandedFile="wacserver2019-kb5002107-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="February 2022" Build="16.0.10383.20001" Url="https://download.microsoft.com/download/d/d/0/dd066fba-30f2-426d-a226-4d00928c0df0/wacserver2019-kb5002133-fullfile-x64-glb.exe" ExpandedFile="wacserver2019-kb5002133-fullfile-x64-glb.exe" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="az-Latn-AZ" Url="https://download.microsoft.com/download/A/0/3/A03B732F-512B-4D29-A2FD-49873FEA60C3/wacserverlanguagepack.exe">
@@ -2425,6 +2438,9 @@
             <CumulativeUpdate Name="December 2021" Build="16.0.14326.20620" Url="https://download.microsoft.com/download/d/9/a/d9adb306-4bc1-4530-919b-12a4f640220c/wssloc-subscription-kb5002047-fullfile-x64-glb.exe" ExpandedFile="wssloc-subscription-kb5002047-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="January 2022" Build="16.0.14326.20714" Url="https://download.microsoft.com/download/d/e/3/de3d7c9f-b5b0-4941-afde-aabb4a7c02be/sts-subscription-kb5002111-fullfile-x64-glb.exe" ExpandedFile="sts-subscription-kb5002111-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="January 2022" Build="16.0.14326.20714" Url="https://download.microsoft.com/download/0/5/f/05fb589e-db35-480f-b7ed-0445f8dd2522/wssloc-subscription-kb5002110-fullfile-x64-glb.exe" ExpandedFile="wssloc-subscription-kb5002110-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="February 2022" Build="16.0.14326.20742" Url="https://download.microsoft.com/download/c/9/f/c9f59585-9ec6-4757-838e-b6ea9cd2bec7/sts-subscription-kb5002145-fullfile-x64-glb.exe" ExpandedFile="sts-subscription-kb5002145-fullfile-x64-glb.exe" />
+            <!--There was no language-dependent fix released for SharePoint SE in February 2022, so the link below is actually for the last-released language-dependent fix (January 2022)-->
+            <CumulativeUpdate Name="February 2022" Build="16.0.14326.20742" Url="https://download.microsoft.com/download/0/5/f/05fb589e-db35-480f-b7ed-0445f8dd2522/wssloc-subscription-kb5002110-fullfile-x64-glb.exe" ExpandedFile="wssloc-subscription-kb5002110-fullfile-x64-glb.exe" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="ar-SA" Url="https://download.microsoft.com/download/d/e/7/de7aa90a-b01c-4123-84be-cdaf41a80bed/ServerLanguagePack.iso">


### PR DESCRIPTION
Fix: CumulativeUpdate Name for ProjectServer2013 CU 15.0.5415.1000 (January 2021 => January 2022)