### PR TITLE
Added September 2022 updates for SP2013, 2016, 2019 and SE

### DIFF
--- a/Scripts/AutoSPSourceBuilder.xml
+++ b/Scripts/AutoSPSourceBuilder.xml
@@ -738,6 +738,9 @@
             <CumulativeUpdate Name="August 2022" Build="15.0.5475.1000" Url="https://download.microsoft.com/download/9/b/f/9bfefde0-7a06-4c8b-8729-085095e10d4f/ubersrv2013-kb5002240-fullfile-x64-glb.exe" ExpandedFile="ubersrv2013-kb5002240-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="August 2022" Build="15.0.5475.1000" Url="https://download.microsoft.com/download/9/b/f/9bfefde0-7a06-4c8b-8729-085095e10d4f/ubersrv_1.cab" ExpandedFile="ubersrv_1.cab" />
             <CumulativeUpdate Name="August 2022" Build="15.0.5475.1000" Url="https://download.microsoft.com/download/9/b/f/9bfefde0-7a06-4c8b-8729-085095e10d4f/ubersrv_2.cab" ExpandedFile="ubersrv_2.cab" />
+            <CumulativeUpdate Name="September 2022" Build="15.0.5485.1000" Url="https://download.microsoft.com/download/b/6/b/b6bc89bf-266e-41f0-9ecf-fb41ad65ffcd/ubersrv2013-kb5002264-fullfile-x64-glb.exe" ExpandedFile="ubersrv2013-kb5002264-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="September 2022" Build="15.0.5485.1000" Url="https://download.microsoft.com/download/b/6/b/b6bc89bf-266e-41f0-9ecf-fb41ad65ffcd/ubersrv_1.cab" ExpandedFile="ubersrv_1.cab" />
+            <CumulativeUpdate Name="September 2022" Build="15.0.5485.1000" Url="https://download.microsoft.com/download/b/6/b/b6bc89bf-266e-41f0-9ecf-fb41ad65ffcd/ubersrv_2.cab" ExpandedFile="ubersrv_2.cab" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="pl-pl" Url="http://download.microsoft.com/download/3/3/3/3331D355-BBAA-4D86-A2AD-FEC7D45261FC/serverlanguagepack.img">
@@ -1497,8 +1500,10 @@
             <!--There was no language-dependent fix released for SharePoint 2016 in July 2022, so the link below is actually for the last-released language-dependent fix (January 2022)-->
             <CumulativeUpdate Name="July 2022" Build="16.0.5344.1000" Url="https://download.microsoft.com/download/c/d/c/cdc66551-193f-4786-843f-c37e522c5025/wssloc2016-kb5002118-fullfile-x64-glb.exe" ExpandedFile="wssloc2016-kb5002118-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="August 2022" Build="16.0.5356.1000" Url="https://download.microsoft.com/download/f/e/5/fe505009-66e2-41e8-be34-45b0f9b76d9e/sts2016-kb5002249-fullfile-x64-glb.exe" ExpandedFile="sts2016-kb5002249-fullfile-x64-glb.exe" />
-            <!--There was no language-dependent fix released for SharePoint 2016 in July 2022, so the link below is actually for the last-released language-dependent fix (January 2022)-->
+            <!--There was no language-dependent fix released for SharePoint 2016 in August 2022, so the link below is actually for the last-released language-dependent fix (January 2022)-->
             <CumulativeUpdate Name="August 2022" Build="16.0.5356.1000" Url="https://download.microsoft.com/download/c/d/c/cdc66551-193f-4786-843f-c37e522c5025/wssloc2016-kb5002118-fullfile-x64-glb.exe" ExpandedFile="wssloc2016-kb5002118-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="September 2022" Build="16.0.5361.1000" Url="https://download.microsoft.com/download/6/b/1/6b18079d-c096-4a8b-b257-c5b90f6d0797/sts2016-kb5002269-fullfile-x64-glb.exe" ExpandedFile="sts2016-kb5002269-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="September 2022" Build="16.0.5361.1000" Url="https://download.microsoft.com/download/3/0/a/30a5b51f-7a4e-4198-bcd2-73017a875503/wssloc2016-kb5002142-fullfile-x64-glb.exe" ExpandedFile="wssloc2016-kb5002142-fullfile-x64-glb.exe" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="az-Latn-AZ" Url="https://download.microsoft.com/download/4/1/7/41789DDA-ABDD-45D2-AAB9-79025E69166B/serverlanguagepack.exe">
@@ -2042,6 +2047,8 @@
             <CumulativeUpdate Name="July 2022" Build="16.0.10388.20004" Url="https://download.microsoft.com/download/a/1/6/a163cec4-9e54-4c0b-8a94-71eaf547cd88/wssloc2019-kb5002230-fullfile-x64-glb.exe" ExpandedFile="wssloc2019-kb5002230-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="August 2022" Build="16.0.10389.20000" Url="https://download.microsoft.com/download/6/5/f/65ff97c4-d8a3-4fe3-bc5b-619f0ec731aa/sts2019-kb5002246-fullfile-x64-glb.exe" ExpandedFile="sts2019-kb5002246-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="August 2022" Build="16.0.10389.20000" Url="https://download.microsoft.com/download/8/1/7/81785973-b491-41ff-b2b2-49f0ae190bdb/wssloc2019-kb5002245-fullfile-x64-glb.exe" ExpandedFile="wssloc2019-kb5002245-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="September 2022" Build="16.0.10390.20000" Url="https://download.microsoft.com/download/0/0/5/0059d3c7-13b2-422b-af14-578c04c597cd/sts2019-kb5002258-fullfile-x64-glb.exe" ExpandedFile="sts2019-kb5002258-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="September 2022" Build="16.0.10390.20000" Url="https://download.microsoft.com/download/c/f/a/cfa28c91-261c-4c02-a9c0-8cd911f0b645/wssloc2019-kb5002257-fullfile-x64-glb.exe" ExpandedFile="wssloc2019-kb5002257-fullfile-x64-glb.exe" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="az-Latn-AZ" Url="https://download.microsoft.com/download/D/6/4/D64A6203-2BB1-43AA-9EA6-365EE5A37E2F/serverlanguagepack.exe">
@@ -2291,6 +2298,7 @@
             <CumulativeUpdate Name="June 2022" Build="16.0.10387.20000" Url="https://download.microsoft.com/download/a/f/6/af619ecf-7fcc-4f93-8778-dc28b0339fc9/wacserver2019-kb5002210-fullfile-x64-glb.exe" ExpandedFile="wacserver2019-kb5002210-fullfile-x64-glb.exe" />
             <!--There was no fix released for Office Online Server 2019 in July 2022-->
             <CumulativeUpdate Name="August 2022" Build="16.0.10389.20000" Url="https://download.microsoft.com/download/0/2/c/02cc5bcf-8d3d-427f-a932-30791be20a9a/wacserver2019-kb5002228-fullfile-x64-glb.exe" ExpandedFile="wacserver2019-kb5002228-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="September 2022" Build="16.0.10390.20000" Url="https://download.microsoft.com/download/8/4/2/8422ffbe-cca7-4e5b-a6eb-ea9d9c8c934d/wacserver2019-kb5002256-fullfile-x64-glb.exe" ExpandedFile="wacserver2019-kb5002256-fullfile-x64-glb.exe" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="az-Latn-AZ" Url="https://download.microsoft.com/download/A/0/3/A03B732F-512B-4D29-A2FD-49873FEA60C3/wacserverlanguagepack.exe">
@@ -2526,6 +2534,8 @@
             <CumulativeUpdate Name="July 2022" Build="16.0.14931.20502" Url="https://download.microsoft.com/download/d/c/8/dc8bd05e-97db-4be2-9745-78712cffc584/wssloc-subscription-kb5002225-fullfile-x64-glb.exe" ExpandedFile="wssloc-subscription-kb5002225-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="August 2022" Build="16.0.14931.20612" Url="https://download.microsoft.com/download/0/0/5/005c3427-fadb-4351-bccc-af31e6463637/sts-subscription-kb5002247-fullfile-x64-glb.exe" ExpandedFile="sts-subscription-kb5002247-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="August 2022" Build="16.0.14931.20612" Url="https://download.microsoft.com/download/0/e/3/0e34a91a-7658-42f3-89c2-f46df11b1dc1/wssloc-subscription-kb5002233-fullfile-x64-glb.exe" ExpandedFile="wssloc-subscription-kb5002233-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="September 2022" Build="16.0.15601.20052" Url="https://download.microsoft.com/download/3/f/5/3f5b1ee0-3336-45d7-b2f4-1e6af977d574/sts-subscription-kb5002271-fullfile-x64-glb.exe" ExpandedFile="sts-subscription-kb5002271-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="September 2022" Build="16.0.15601.20052" Url="https://download.microsoft.com/download/8/d/f/8dfcb515-6e49-42e5-b20f-5ebdfd19d8e7/wssloc-subscription-kb5002270-fullfile-x64-glb.exe" ExpandedFile="wssloc-subscription-kb5002270-fullfile-x64-glb.exe" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="ar-SA" Url="https://download.microsoft.com/download/d/e/7/de7aa90a-b01c-4123-84be-cdaf41a80bed/ServerLanguagePack.iso">


### PR DESCRIPTION
- **Attention there are known issues for SP2013, 2016, 2019 and SE** 
For details see: 
[Please review the “Known issues” section of the KB articles for SharePoint September 2022 CU / PU](https://blog.stefan-gossner.com/2022/09/13/please-review-the-known-issues-section-of-the-kb-articles-for-september-2022-cu-pu/)

- **Updates for SE includes Feature Update 22H2**
For details see: 
[Feature Update 22H2 for SharePoint Server Subscription Edition has been released today](https://blog.stefan-gossner.com/2022/09/13/feature-update-22h2-for-sharepoint-server-subscription-edition-has-been-released-today/)
[New and improved features in SharePoint Server Subscription Edition Version 22H2](https://docs.microsoft.com/en-us/sharepoint/what-s-new/new-and-improved-features-in-sharepoint-server-subscription-edition-22h2-release)