### PR TITLE
August 2024 updates for SharePoint 2019/SE

### DIFF
--- a/Scripts/AutoSPSourceBuilder.xml
+++ b/Scripts/AutoSPSourceBuilder.xml
@@ -2200,6 +2200,8 @@
             <CumulativeUpdate Name="July 2024" Build="16.0.10412.20001" Url="https://download.microsoft.com/download/b/d/c/bdcaf12b-3153-4125-946c-d4a8f0f99175/sts2019-kb5002615-fullfile-x64-glb.exe" ExpandedFile="sts2019-kb5002615-fullfile-x64-glb.exe" />
             <!--There was no language-dependent fix released for SharePoint 2019 in July 2024", so the link below is actually for the last-released language-dependent fix (April 2024)-->
             <CumulativeUpdate Name="July 2024" Build="16.0.10412.20001" Url="https://download.microsoft.com/download/7/e/8/7e8afdd8-5b84-4543-87c2-bdb89858516a/wssloc2019-kb5002538-fullfile-x64-glb.exe" ExpandedFile="wssloc2019-kb5002538-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="August 2024" Build="16.0.10413.20000" Url="https://download.microsoft.com/download/2/d/7/2d77aff4-b800-4e65-b907-7d7e442e07e8/sts2019-kb5002630-fullfile-x64-glb.exe" ExpandedFile="sts2019-kb5002630-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="August 2024" Build="16.0.10413.20000" Url="https://download.microsoft.com/download/4/c/2/4c2d9fcb-b467-4486-bdb5-90d5f50a0165/wssloc2019-kb5002597-fullfile-x64-glb.exe" ExpandedFile="wssloc2019-kb5002597-fullfile-x64-glb.exe" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="az-Latn-AZ" Url="https://download.microsoft.com/download/D/6/4/D64A6203-2BB1-43AA-9EA6-365EE5A37E2F/serverlanguagepack.exe">
@@ -2737,6 +2739,7 @@
             <CumulativeUpdate Name="May 2024" Build="16.0.17328.20292" Url="https://download.microsoft.com/download/b/f/8/bf882ae0-a5f0-4c11-b320-4c82a1ed7d8d/uber-subscription-kb5002599-fullfile-x64-glb.exe" ExpandedFile="uber-subscription-kb5002599-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="June 2024" Build="16.0.17328.20362" Url="https://download.microsoft.com/download/5/8/f/58fcfd0c-a364-4e96-a4f2-95c421279785/uber-subscription-kb5002603-fullfile-x64-glb.exe" ExpandedFile="uber-subscription-kb5002603-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="July 2024" Build="16.0.17328.20424" Url="https://download.microsoft.com/download/c/2/0/c20b87cc-da05-4793-bd7b-c424a6a6df33/uber-subscription-kb5002606-fullfile-x64-glb.exe" ExpandedFile="uber-subscription-kb5002606-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="August 2024" Build="16.0.17328.20478" Url="https://download.microsoft.com/download/9/0/b/90b9d2b0-0f76-408d-950f-b3b2f3c50c83/uber-subscription-kb5002629-fullfile-x64-glb.exe" ExpandedFile="uber-subscription-kb5002629-fullfile-x64-glb.exe" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="ar-SA" Url="https://download.microsoft.com/download/d/e/7/de7aa90a-b01c-4123-84be-cdaf41a80bed/ServerLanguagePack.iso">

--- a/Scripts/AutoSPSourceBuilder.xml
+++ b/Scripts/AutoSPSourceBuilder.xml
@@ -1598,6 +1598,9 @@
             <CumulativeUpdate Name="June 2024" Build="16.0.5452.1000" Url="https://download.microsoft.com/download/5/9/d/59d2cfdb-abb1-4e0f-b072-7bba9b8e2952/sts2016-kb5002604-fullfile-x64-glb.exe" ExpandedFile="sts2016-kb5002604-fullfile-x64-glb.exe" />
             <!--There was no language-dependent fix released for SharePoint 2016 in June 2024, so the link below is actually for the last-released language-dependent fix (December 2023)-->
             <CumulativeUpdate Name="June 2024" Build="16.0.5452.1000" Url="https://download.microsoft.com/download/0/2/9/029a76b8-aa40-42de-b689-9bca06bc2198/wssloc2016-kb5002524-fullfile-x64-glb.exe" ExpandedFile="wssloc2016-kb5002524-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="July 2024" Build="16.0.5456.1000" Url="https://download.microsoft.com/download/d/d/6/dd63db3f-c434-42dc-89c8-7f06d42fdf9f/sts2016-kb5002618-fullfile-x64-glb.exe" ExpandedFile="sts2016-kb5002618-fullfile-x64-glb.exe" />
+            <!--There was no language-dependent fix released for SharePoint 2016 in July 2024, so the link below is actually for the last-released language-dependent fix (December 2023)-->
+            <CumulativeUpdate Name="July 2024" Build="16.0.5456.1000" Url="https://download.microsoft.com/download/0/2/9/029a76b8-aa40-42de-b689-9bca06bc2198/wssloc2016-kb5002524-fullfile-x64-glb.exe" ExpandedFile="wssloc2016-kb5002524-fullfile-x64-glb.exe" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="az-Latn-AZ" Url="https://download.microsoft.com/download/4/1/7/41789DDA-ABDD-45D2-AAB9-79025E69166B/serverlanguagepack.exe">
@@ -2189,11 +2192,14 @@
             <CumulativeUpdate Name="April 2024" Build="16.0.10409.20027" Url="https://download.microsoft.com/download/0/7/6/07692253-ef3f-4197-8409-bc4610a7d773/sts2019-kb5002580-fullfile-x64-glb.exe" ExpandedFile="sts2019-kb5002580-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="April 2024" Build="16.0.10409.20027" Url="https://download.microsoft.com/download/7/e/8/7e8afdd8-5b84-4543-87c2-bdb89858516a/wssloc2019-kb5002538-fullfile-x64-glb.exe" ExpandedFile="wssloc2019-kb5002538-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="May 2024" Build="16.0.10410.20003" Url="https://download.microsoft.com/download/1/5/0/150b5f23-cd97-4d31-a6b2-b0b8f6078f39/sts2019-kb5002596-fullfile-x64-glb.exe" ExpandedFile="sts2019-kb5002596-fullfile-x64-glb.exe" />
-            <!--There was no language-dependent fix released for SharePoint 2019 in May 2024", so the link below is actually for the last-released language-dependent fix (April 2023)-->
+            <!--There was no language-dependent fix released for SharePoint 2019 in May 2024", so the link below is actually for the last-released language-dependent fix (April 2024)-->
             <CumulativeUpdate Name="May 2024" Build="16.0.10410.20003" Url="https://download.microsoft.com/download/7/e/8/7e8afdd8-5b84-4543-87c2-bdb89858516a/wssloc2019-kb5002538-fullfile-x64-glb.exe" ExpandedFile="wssloc2019-kb5002538-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="June 2024" Build="16.0.10411.20004" Url="https://download.microsoft.com/download/e/3/2/e3231c65-cb45-4b8d-a2f6-064cec512702/sts2019-kb5002602-fullfile-x64-glb.exe" ExpandedFile="sts2019-kb5002602-fullfile-x64-glb.exe" />
-            <!--There was no language-dependent fix released for SharePoint 2019 in June 2024", so the link below is actually for the last-released language-dependent fix (April 2023)-->
+            <!--There was no language-dependent fix released for SharePoint 2019 in June 2024", so the link below is actually for the last-released language-dependent fix (April 2024)-->
             <CumulativeUpdate Name="June 2024" Build="16.0.10411.20004" Url="https://download.microsoft.com/download/7/e/8/7e8afdd8-5b84-4543-87c2-bdb89858516a/wssloc2019-kb5002538-fullfile-x64-glb.exe" ExpandedFile="wssloc2019-kb5002538-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="July 2024" Build="16.0.10412.20001" Url="https://download.microsoft.com/download/b/d/c/bdcaf12b-3153-4125-946c-d4a8f0f99175/sts2019-kb5002615-fullfile-x64-glb.exe" ExpandedFile="sts2019-kb5002615-fullfile-x64-glb.exe" />
+            <!--There was no language-dependent fix released for SharePoint 2019 in July 2024", so the link below is actually for the last-released language-dependent fix (April 2024)-->
+            <CumulativeUpdate Name="July 2024" Build="16.0.10412.20001" Url="https://download.microsoft.com/download/7/e/8/7e8afdd8-5b84-4543-87c2-bdb89858516a/wssloc2019-kb5002538-fullfile-x64-glb.exe" ExpandedFile="wssloc2019-kb5002538-fullfile-x64-glb.exe" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="az-Latn-AZ" Url="https://download.microsoft.com/download/D/6/4/D64A6203-2BB1-43AA-9EA6-365EE5A37E2F/serverlanguagepack.exe">
@@ -2730,6 +2736,7 @@
             <CumulativeUpdate Name="April 2024" Build="16.0.17328.20246" Url="https://download.microsoft.com/download/b/d/8/bd8f3278-11ae-4f3f-8d81-8188ca3457a6/uber-subscription-kb5002581-fullfile-x64-glb.exe" ExpandedFile="uber-subscription-kb5002581-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="May 2024" Build="16.0.17328.20292" Url="https://download.microsoft.com/download/b/f/8/bf882ae0-a5f0-4c11-b320-4c82a1ed7d8d/uber-subscription-kb5002599-fullfile-x64-glb.exe" ExpandedFile="uber-subscription-kb5002599-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="June 2024" Build="16.0.17328.20362" Url="https://download.microsoft.com/download/5/8/f/58fcfd0c-a364-4e96-a4f2-95c421279785/uber-subscription-kb5002603-fullfile-x64-glb.exe" ExpandedFile="uber-subscription-kb5002603-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="July 2024" Build="16.0.17328.20424" Url="https://download.microsoft.com/download/c/2/0/c20b87cc-da05-4793-bd7b-c424a6a6df33/uber-subscription-kb5002606-fullfile-x64-glb.exe" ExpandedFile="uber-subscription-kb5002606-fullfile-x64-glb.exe" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="ar-SA" Url="https://download.microsoft.com/download/d/e/7/de7aa90a-b01c-4123-84be-cdaf41a80bed/ServerLanguagePack.iso">

--- a/Scripts/AutoSPSourceBuilder.xml
+++ b/Scripts/AutoSPSourceBuilder.xml
@@ -2464,7 +2464,7 @@
             <CumulativeUpdate Name="July 2023" Build="16.0.10400.20000" Url="https://download.microsoft.com/download/6/2/0/620911da-8afd-4cb0-8822-63bcac5fd103/wacserver2019-kb5002421-fullfile-x64-glb.exe" ExpandedFile="wacserver2019-kb5002421-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="August 2023" Build="16.0.10401.20022" Url="https://download.microsoft.com/download/2/4/c/24cc6dda-b530-49d2-9632-917ffb42d611/wacserver2019-kb5002435-fullfile-x64-glb.exe" ExpandedFile="wacserver2019-kb5002435-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="September 2023" Build="16.0.10402.20000" Url="https://download.microsoft.com/download/7/2/0/7202f280-d3f2-444d-9658-24aed2db6afd/wacserver2019-kb5002470-fullfile-x64-glb.exe" ExpandedFile="wacserver2019-kb5002470-fullfile-x64-glb.exe" />
-            <CumulativeUpdate Name="May 2023" Build="16.0.10410.20003" Url="https://download.microsoft.com/download/2/7/4/27485255-e780-4fde-b4dd-5723addfbd7e/wacserver2019-kb5002503-fullfile-x64-glb.exe" ExpandedFile="wacserver2019-kb5002503-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="May 2024" Build="16.0.10410.20003" Url="https://download.microsoft.com/download/2/7/4/27485255-e780-4fde-b4dd-5723addfbd7e/wacserver2019-kb5002503-fullfile-x64-glb.exe" ExpandedFile="wacserver2019-kb5002503-fullfile-x64-glb.exe" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="az-Latn-AZ" Url="https://download.microsoft.com/download/A/0/3/A03B732F-512B-4D29-A2FD-49873FEA60C3/wacserverlanguagepack.exe">


### PR DESCRIPTION
- August 2024 updates for SharePoint 2019/SE
- July 2024 updates for SharePoint 2016/2019/SE

Includes / replaces #134 and #135

There are are known / trending issues since July 2024 CU for SharePoint 2016 and SharePoint 2019. A fix is planned for September 2024. 

For details see: 

- [Trending Issue: Certain Powershell operations failing after installing July 2024 CU for SharePoint 2016/2019](https://blog.stefan-gossner.com/2024/07/22/trending-issue-certain-powershell-operations-failing-after-installing-july-2024-cu-for-sharepoint-2016-2019/)
- KB [5002618](https://support.microsoft.com/en-us/kb/5002618) – July 2024 CU for SharePoint Server 2016
- KB [5002615](https://support.microsoft.com/en-us/kb/5002615) – July 2024 CU for SharePoint Server 2019