### PR TITLE
July 2025 for SharePoint 2016/2019/SE (vulnerability CVE-2025-53770)

### DIFF
--- a/Scripts/AutoSPSourceBuilder.xml
+++ b/Scripts/AutoSPSourceBuilder.xml
@@ -1629,8 +1629,11 @@
             <CumulativeUpdate Name="May 2025" Build="16.0.5500.1001" Url="https://download.microsoft.com/download/ef62a2b2-913b-4c04-a58a-4dbdce756924/wssloc2016-kb5002712-fullfile-x64-glb.exe" ExpandedFile="wssloc2016-kb5002712-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="June 2025" Build="16.0.5504.1001" Url="https://download.microsoft.com/download/dd9a9649-8cf4-471f-b1d9-cef5e11ce181/sts2016-kb5002732-fullfile-x64-glb.exe" ExpandedFile="sts2016-kb5002732-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="June 2025" Build="16.0.5504.1001" Url="https://download.microsoft.com/download/aeaa67b7-b5d3-4b39-8015-ba584cdbd115/wssloc2016-kb5002731-fullfile-x64-glb.exe" ExpandedFile="wssloc2016-kb5002731-fullfile-x64-glb.exe" />
-            <CumulativeUpdate Name="July 2025" Build="16.0.5508.1000" Url="https://download.microsoft.com/download/3beda9c6-ee92-4d35-891e-25eab622aea5/sts2016-kb5002744-fullfile-x64-glb.exe" ExpandedFile="sts2016-kb5002744-fullfile-x64-glb.exe" />
-            <CumulativeUpdate Name="July 2025" Build="16.0.5508.1000" Url="https://download.microsoft.com/download/7b4d9c50-d0c7-4a33-9b1b-3927ff1c51c8/wssloc2016-kb5002743-fullfile-x64-glb.exe" ExpandedFile="wssloc2016-kb5002743-fullfile-x64-glb.exe" />
+            <!--<CumulativeUpdate Name="July 2025" Build="16.0.5508.1000" Url="https://download.microsoft.com/download/3beda9c6-ee92-4d35-891e-25eab622aea5/sts2016-kb5002744-fullfile-x64-glb.exe" ExpandedFile="sts2016-kb5002744-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="July 2025" Build="16.0.5508.1000" Url="https://download.microsoft.com/download/7b4d9c50-d0c7-4a33-9b1b-3927ff1c51c8/wssloc2016-kb5002743-fullfile-x64-glb.exe" ExpandedFile="wssloc2016-kb5002743-fullfile-x64-glb.exe" />-->
+            <CumulativeUpdate Name="July 2025" Build="16.0.5513.1001" Url="https://download.microsoft.com/download/6fab547a-d8ff-4152-a2b0-f65c4c9a27e4/sts2016-kb5002760-fullfile-x64-glb.exe" ExpandedFile="sts2016-kb5002760-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="July 2025" Build="16.0.5513.1001" Url="https://download.microsoft.com/download/385fd5e7-e818-43b2-85db-1815d38145f7/wssloc2016-kb5002759-fullfile-x64-glb.exe" ExpandedFile="wssloc2016-kb5002759-fullfile-x64-glb.exe" />
+            
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="az-Latn-AZ" Url="https://download.microsoft.com/download/4/1/7/41789DDA-ABDD-45D2-AAB9-79025E69166B/serverlanguagepack.exe">

--- a/Scripts/AutoSPSourceBuilder.xml
+++ b/Scripts/AutoSPSourceBuilder.xml
@@ -2255,8 +2255,10 @@
             <CumulativeUpdate Name="May 2025" Build="16.0.10417.20010" Url="https://download.microsoft.com/download/1478b2e5-5421-44dd-aba3-8738c6168cc6/wssloc2019-kb5002706-fullfile-x64-glb.exe" ExpandedFile="wssloc2019-kb5002706-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="June 2025" Build="16.0.10417.20018" Url="https://download.microsoft.com/download/32736987-8572-4f58-8b18-f072399917b9/sts2019-kb5002729-fullfile-x64-glb.exe" ExpandedFile="sts2019-kb5002729-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="June 2025" Build="16.0.10417.20018" Url="https://download.microsoft.com/download/146b0447-b399-4cc1-9470-ca68d1596bc1/wssloc2019-kb5002727-fullfile-x64-glb.exe" ExpandedFile="wssloc2019-kb5002727-fullfile-x64-glb.exe" />
-            <CumulativeUpdate Name="July 2025" Build="16.0.10417.20027" Url="https://download.microsoft.com/download/ef2fe4ee-1be2-4c88-9aee-9ece6ba35a19/sts2019-kb5002741-fullfile-x64-glb.exe" ExpandedFile="sts2019-kb5002741-fullfile-x64-glb.exe" />
-            <CumulativeUpdate Name="July 2025" Build="16.0.10417.20027" Url="https://download.microsoft.com/download/c537c231-5fd1-4cad-845c-6af8333ff45f/wssloc2019-kb5002739-fullfile-x64-glb.exe" ExpandedFile="wssloc2019-kb5002739-fullfile-x64-glb.exe" />
+            <!--<CumulativeUpdate Name="July 2025" Build="16.0.10417.20027" Url="https://download.microsoft.com/download/ef2fe4ee-1be2-4c88-9aee-9ece6ba35a19/sts2019-kb5002741-fullfile-x64-glb.exe" ExpandedFile="sts2019-kb5002741-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="July 2025" Build="16.0.10417.20027" Url="https://download.microsoft.com/download/c537c231-5fd1-4cad-845c-6af8333ff45f/wssloc2019-kb5002739-fullfile-x64-glb.exe" ExpandedFile="wssloc2019-kb5002739-fullfile-x64-glb.exe" />-->
+            <CumulativeUpdate Name="July 2025" Build="16.0.10417.20037" Url="https://download.microsoft.com/download/831702e4-0c45-4c0e-b5ac-f5504b85c056/sts2019-kb5002754-fullfile-x64-glb.exe" ExpandedFile="sts2019-kb5002754-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="July 2025" Build="16.0.10417.20037" Url="https://download.microsoft.com/download/c537c231-5fd1-4cad-845c-6af8333ff45f/wssloc2019-kb5002739-fullfile-x64-glb.exe" ExpandedFile="wssloc2019-kb5002739-fullfile-x64-glb.exe" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="az-Latn-AZ" Url="https://download.microsoft.com/download/D/6/4/D64A6203-2BB1-43AA-9EA6-365EE5A37E2F/serverlanguagepack.exe">
@@ -2815,7 +2817,8 @@
             <CumulativeUpdate Name="April 2025" Build="16.0.18526.20172" Url="https://download.microsoft.com/download/8ae22e05-14eb-401b-b979-ab2d2853c1e5/uber-subscription-kb5002705-fullfile-x64-glb.exe" ExpandedFile="uber-subscription-kb5002705-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="May 2025" Build="16.0.18526.20286" Url="https://download.microsoft.com/download/0d0fac81-9f1b-4f9f-9269-0798f9e0666c/uber-subscription-kb5002709-fullfile-x64-glb.exe" ExpandedFile="uber-subscription-kb5002709-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="June 2025" Build="16.0.18526.20396" Url="https://download.microsoft.com/download/159a5f7c-b1ac-46c1-83e8-5949090ddcb1/uber-subscription-kb5002736-fullfile-x64-glb.exe" ExpandedFile="uber-subscription-kb5002736-fullfile-x64-glb.exe" />
-            <CumulativeUpdate Name="July 2025" Build="16.0.18526.20424" Url="https://download.microsoft.com/download/45736d53-3c43-430b-b6ee-7f56c29afff6/uber-subscription-kb5002751-fullfile-x64-glb.exe" ExpandedFile="uber-subscription-kb5002751-fullfile-x64-glb.exe" />
+            <!--<CumulativeUpdate Name="July 2025" Build="16.0.18526.20424" Url="https://download.microsoft.com/download/45736d53-3c43-430b-b6ee-7f56c29afff6/uber-subscription-kb5002751-fullfile-x64-glb.exe" ExpandedFile="uber-subscription-kb5002751-fullfile-x64-glb.exe" />-->
+            <CumulativeUpdate Name="July 2025" Build="16.0.18526.20508" Url="https://download.microsoft.com/download/e1f1440c-1192-4096-b9c9-31970e79671c/uber-subscription-kb5002768-fullfile-x64-glb.exe" ExpandedFile="uberuber-subscription-kb5002768-fullfile-x64-glb.exe" />            
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="ar-SA" Url="https://download.microsoft.com/download/d/e/7/de7aa90a-b01c-4123-84be-cdaf41a80bed/ServerLanguagePack.iso">

--- a/Scripts/AutoSPSourceBuilder.xml
+++ b/Scripts/AutoSPSourceBuilder.xml
@@ -2821,7 +2821,7 @@
             <CumulativeUpdate Name="May 2025" Build="16.0.18526.20286" Url="https://download.microsoft.com/download/0d0fac81-9f1b-4f9f-9269-0798f9e0666c/uber-subscription-kb5002709-fullfile-x64-glb.exe" ExpandedFile="uber-subscription-kb5002709-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="June 2025" Build="16.0.18526.20396" Url="https://download.microsoft.com/download/159a5f7c-b1ac-46c1-83e8-5949090ddcb1/uber-subscription-kb5002736-fullfile-x64-glb.exe" ExpandedFile="uber-subscription-kb5002736-fullfile-x64-glb.exe" />
             <!--<CumulativeUpdate Name="July 2025" Build="16.0.18526.20424" Url="https://download.microsoft.com/download/45736d53-3c43-430b-b6ee-7f56c29afff6/uber-subscription-kb5002751-fullfile-x64-glb.exe" ExpandedFile="uber-subscription-kb5002751-fullfile-x64-glb.exe" />-->
-            <CumulativeUpdate Name="July 2025" Build="16.0.18526.20508" Url="https://download.microsoft.com/download/e1f1440c-1192-4096-b9c9-31970e79671c/uber-subscription-kb5002768-fullfile-x64-glb.exe" ExpandedFile="uberuber-subscription-kb5002768-fullfile-x64-glb.exe" />            
+            <CumulativeUpdate Name="July 2025" Build="16.0.18526.20508" Url="https://download.microsoft.com/download/e1f1440c-1192-4096-b9c9-31970e79671c/uber-subscription-kb5002768-fullfile-x64-glb.exe" ExpandedFile="uber-subscription-kb5002768-fullfile-x64-glb.exe" />            
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="ar-SA" Url="https://download.microsoft.com/download/d/e/7/de7aa90a-b01c-4123-84be-cdaf41a80bed/ServerLanguagePack.iso">


### PR DESCRIPTION
Details: [Customer guidance for SharePoint vulnerability CVE-2025-53770](https://msrc.microsoft.com/blog/2025/07/customer-guidance-for-sharepoint-vulnerability-cve-2025-53770/)