### PR TITLE
October 2025 updates for SharePoint 2016/2019/SE and OOS

### DIFF
--- a/Scripts/AutoSPSourceBuilder.xml
+++ b/Scripts/AutoSPSourceBuilder.xml
@@ -1637,6 +1637,8 @@
             <CumulativeUpdate Name="August 2025" Build="16.0.5513.1002" Url="https://download.microsoft.com/download/8252eeac-d461-42b6-baf6-af42a8be81e7/wssloc2016-kb5002772-fullfile-x64-glb.exe" ExpandedFile="wssloc2016-kb5002772-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="September 2025" Build="16.0.5517.1000" Url="https://download.microsoft.com/download/4dca447e-d84b-4f64-be96-431672474685/sts2016-kb5002778-fullfile-x64-glb.exe" ExpandedFile="sts2016-kb5002778-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="September 2025" Build="16.0.5517.1000" Url="https://download.microsoft.com/download/5905cf5e-c998-404d-853d-bc119e237e78/wssloc2016-kb5002777-fullfile-x64-glb.exe" ExpandedFile="wssloc2016-kb5002777-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="October 2025" Build="16.0.5522.1000" Url="https://download.microsoft.com/download/b0038b3f-d8c6-4ba7-81c8-f45c0529491c/sts2016-kb5002788-fullfile-x64-glb.exe" ExpandedFile="sts2016-kb5002788-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="October 2025" Build="16.0.5522.1000" Url="https://download.microsoft.com/download/5728779d-9032-45be-aecf-915595ca35b5/wssloc2016-kb5002787-fullfile-x64-glb.exe" ExpandedFile="wssloc2016-kb5002787-fullfile-x64-glb.exe" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="az-Latn-AZ" Url="https://download.microsoft.com/download/4/1/7/41789DDA-ABDD-45D2-AAB9-79025E69166B/serverlanguagepack.exe">
@@ -2269,6 +2271,8 @@
             <CumulativeUpdate Name="August 2025" Build="16.0.10417.20041" Url="https://download.microsoft.com/download/9ac71105-631e-4975-831d-c1c14e1de793/wssloc2019-kb5002770-fullfile-x64-glb.exe" ExpandedFile="wssloc2019-kb5002770-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="September 2025" Build="16.0.10417.20047" Url="https://download.microsoft.com/download/ee9d1671-7c1e-41c1-a65b-2d610cbfa0be/sts2019-kb5002775-fullfile-x64-glb.exe" ExpandedFile="sts2019-kb5002775-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="September 2025" Build="16.0.10417.20047" Url="https://download.microsoft.com/download/9c8f84c6-b6cc-491e-87c7-754e42e015b1/wssloc2019-kb5002774-fullfile-x64-glb.exe" ExpandedFile="wssloc2019-kb5002774-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="October 2025" Build="16.0.10417.20059" Url="https://download.microsoft.com/download/6de19311-e983-4aa5-8ae0-e65ed4457167/sts2019-kb5002796-fullfile-x64-glb.exe" ExpandedFile="sts2019-kb5002796-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="October 2025" Build="16.0.10417.20059" Url="https://download.microsoft.com/download/783793f8-70a8-40a3-8795-93ec475fa8f8/wssloc2019-kb5002798-fullfile-x64-glb.exe" ExpandedFile="wssloc2019-kb5002798-fullfile-x64-glb.exe" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="az-Latn-AZ" Url="https://download.microsoft.com/download/D/6/4/D64A6203-2BB1-43AA-9EA6-365EE5A37E2F/serverlanguagepack.exe">
@@ -2544,6 +2548,7 @@
             <CumulativeUpdate Name="July 2025" Build="16.0.10417.20027" Url="https://download.microsoft.com/download/2f85bd67-2a4b-4308-8efc-87ece24c8ed2/wacserver2019-kb5002740-fullfile-x64-glb.exe" ExpandedFile="wacserver2019-kb5002740-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="August 2025" Build="16.0.10417.20034" Url="https://download.microsoft.com/download/db2b65d9-f5f9-49ce-9de9-d6cfb86180bf/wacserver2019-kb5002752-fullfile-x64-glb.exe" ExpandedFile="wacserver2019-kb5002752-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="September 2025" Build="16.0.10417.20047" Url="https://download.microsoft.com/download/269a4b79-ac67-40d9-8280-910cfb5f25fc/wacserver2019-kb5002776-fullfile-x64-glb.exe" ExpandedFile="wacserver2019-kb5002776-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="October 2025" Build="16.0.10417.20059" Url="https://download.microsoft.com/download/1ac8c634-9443-4075-baf3-d670d27b0b30/wacserver2019-kb5002797-fullfile-x64-glb.exe" ExpandedFile="wacserver2019-kb5002797-fullfile-x64-glb.exe" />            
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="az-Latn-AZ" Url="https://download.microsoft.com/download/A/0/3/A03B732F-512B-4D29-A2FD-49873FEA60C3/wacserverlanguagepack.exe">
@@ -2833,6 +2838,7 @@
             <CumulativeUpdate Name="July 2025" Build="16.0.18526.20508" Url="https://download.microsoft.com/download/e1f1440c-1192-4096-b9c9-31970e79671c/uber-subscription-kb5002768-fullfile-x64-glb.exe" ExpandedFile="uber-subscription-kb5002768-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="August 2025" Build="16.0.18526.20518" Url="https://download.microsoft.com/download/fb4b4f82-bff0-4e14-9171-15c034549bb1/uber-subscription-kb5002773-fullfile-x64-glb.exe" ExpandedFile="uber-subscription-kb5002773-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="September 2025" Build="16.0.19127.20100" Url="https://download.microsoft.com/download/0ae39b29-890d-428c-bcee-c93eeca2053b/uber-subscription-kb5002784-fullfile-x64-glb.exe" ExpandedFile="uber-subscription-kb5002784-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="October 2025" Build="16.0.19127.20262" Url="https://download.microsoft.com/download/24cab3c4-d5bb-486a-a57b-3e8fb5bd5e28/uber-subscription-kb5002786-fullfile-x64-glb.exe" ExpandedFile="uber-subscription-kb5002786-fullfile-x64-glb.exe" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="ar-SA" Url="https://download.microsoft.com/download/d/e/7/de7aa90a-b01c-4123-84be-cdaf41a80bed/ServerLanguagePack.iso">

--- a/Scripts/AutoSPSourceBuilder.xml
+++ b/Scripts/AutoSPSourceBuilder.xml
@@ -1634,7 +1634,9 @@
             <CumulativeUpdate Name="July 2025" Build="16.0.5513.1001" Url="https://download.microsoft.com/download/6fab547a-d8ff-4152-a2b0-f65c4c9a27e4/sts2016-kb5002760-fullfile-x64-glb.exe" ExpandedFile="sts2016-kb5002760-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="July 2025" Build="16.0.5513.1001" Url="https://download.microsoft.com/download/385fd5e7-e818-43b2-85db-1815d38145f7/wssloc2016-kb5002759-fullfile-x64-glb.exe" ExpandedFile="wssloc2016-kb5002759-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="August 2025" Build="16.0.5513.1002" Url="https://download.microsoft.com/download/4afb74cf-deaf-40e4-96fe-4d45c1f980e7/sts2016-kb5002771-fullfile-x64-glb.exe" ExpandedFile="sts2016-kb5002771-fullfile-x64-glb.exe" />
-            <CumulativeUpdate Name="August 2025" Build="16.0.5513.1002" Url="https://download.microsoft.com/download/8252eeac-d461-42b6-baf6-af42a8be81e7/wssloc2016-kb5002772-fullfile-x64-glb.exe" ExpandedFile="wssloc2016-kb5002772-fullfile-x64-glb.exe" />            
+            <CumulativeUpdate Name="August 2025" Build="16.0.5513.1002" Url="https://download.microsoft.com/download/8252eeac-d461-42b6-baf6-af42a8be81e7/wssloc2016-kb5002772-fullfile-x64-glb.exe" ExpandedFile="wssloc2016-kb5002772-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="September 2025" Build="16.0.5517.1000" Url="https://download.microsoft.com/download/4dca447e-d84b-4f64-be96-431672474685/sts2016-kb5002778-fullfile-x64-glb.exe" ExpandedFile="sts2016-kb5002778-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="September 2025" Build="16.0.5517.1000" Url="https://download.microsoft.com/download/5905cf5e-c998-404d-853d-bc119e237e78/wssloc2016-kb5002777-fullfile-x64-glb.exe" ExpandedFile="wssloc2016-kb5002777-fullfile-x64-glb.exe" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="az-Latn-AZ" Url="https://download.microsoft.com/download/4/1/7/41789DDA-ABDD-45D2-AAB9-79025E69166B/serverlanguagepack.exe">
@@ -2265,6 +2267,8 @@
             <CumulativeUpdate Name="July 2025" Build="16.0.10417.20037" Url="https://download.microsoft.com/download/c537c231-5fd1-4cad-845c-6af8333ff45f/wssloc2019-kb5002739-fullfile-x64-glb.exe" ExpandedFile="wssloc2019-kb5002739-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="August 2025" Build="16.0.10417.20041" Url="https://download.microsoft.com/download/4432b588-5754-4a41-8055-6b4b287d2f64/sts2019-kb5002769-fullfile-x64-glb.exe" ExpandedFile="sts2019-kb5002769-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="August 2025" Build="16.0.10417.20041" Url="https://download.microsoft.com/download/9ac71105-631e-4975-831d-c1c14e1de793/wssloc2019-kb5002770-fullfile-x64-glb.exe" ExpandedFile="wssloc2019-kb5002770-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="September 2025" Build="16.0.10417.20047" Url="https://download.microsoft.com/download/ee9d1671-7c1e-41c1-a65b-2d610cbfa0be/sts2019-kb5002775-fullfile-x64-glb.exe" ExpandedFile="sts2019-kb5002775-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="September 2025" Build="16.0.10417.20047" Url="https://download.microsoft.com/download/9c8f84c6-b6cc-491e-87c7-754e42e015b1/wssloc2019-kb5002774-fullfile-x64-glb.exe" ExpandedFile="wssloc2019-kb5002774-fullfile-x64-glb.exe" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="az-Latn-AZ" Url="https://download.microsoft.com/download/D/6/4/D64A6203-2BB1-43AA-9EA6-365EE5A37E2F/serverlanguagepack.exe">
@@ -2539,6 +2543,7 @@
             <CumulativeUpdate Name="June 2025" Build="16.0.10417.20018" Url="https://download.microsoft.com/download/3cb1b313-3634-40eb-96c5-7b3e17e6559c/wacserver2019-kb5002728-fullfile-x64-glb.exe" ExpandedFile="wacserver2019-kb5002728-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="July 2025" Build="16.0.10417.20027" Url="https://download.microsoft.com/download/2f85bd67-2a4b-4308-8efc-87ece24c8ed2/wacserver2019-kb5002740-fullfile-x64-glb.exe" ExpandedFile="wacserver2019-kb5002740-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="August 2025" Build="16.0.10417.20034" Url="https://download.microsoft.com/download/db2b65d9-f5f9-49ce-9de9-d6cfb86180bf/wacserver2019-kb5002752-fullfile-x64-glb.exe" ExpandedFile="wacserver2019-kb5002752-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="September 2025" Build="16.0.10417.20047" Url="https://download.microsoft.com/download/269a4b79-ac67-40d9-8280-910cfb5f25fc/wacserver2019-kb5002776-fullfile-x64-glb.exe" ExpandedFile="wacserver2019-kb5002776-fullfile-x64-glb.exe" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="az-Latn-AZ" Url="https://download.microsoft.com/download/A/0/3/A03B732F-512B-4D29-A2FD-49873FEA60C3/wacserverlanguagepack.exe">
@@ -2827,6 +2832,7 @@
             <!--<CumulativeUpdate Name="July 2025" Build="16.0.18526.20424" Url="https://download.microsoft.com/download/45736d53-3c43-430b-b6ee-7f56c29afff6/uber-subscription-kb5002751-fullfile-x64-glb.exe" ExpandedFile="uber-subscription-kb5002751-fullfile-x64-glb.exe" />-->
             <CumulativeUpdate Name="July 2025" Build="16.0.18526.20508" Url="https://download.microsoft.com/download/e1f1440c-1192-4096-b9c9-31970e79671c/uber-subscription-kb5002768-fullfile-x64-glb.exe" ExpandedFile="uber-subscription-kb5002768-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="August 2025" Build="16.0.18526.20518" Url="https://download.microsoft.com/download/fb4b4f82-bff0-4e14-9171-15c034549bb1/uber-subscription-kb5002773-fullfile-x64-glb.exe" ExpandedFile="uber-subscription-kb5002773-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="September 2025" Build="16.0.19127.20100" Url="https://download.microsoft.com/download/0ae39b29-890d-428c-bcee-c93eeca2053b/uber-subscription-kb5002784-fullfile-x64-glb.exe" ExpandedFile="uber-subscription-kb5002784-fullfile-x64-glb.exe" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="ar-SA" Url="https://download.microsoft.com/download/d/e/7/de7aa90a-b01c-4123-84be-cdaf41a80bed/ServerLanguagePack.iso">


### PR DESCRIPTION
**Be careful installing September 2025 updates for SharePoint 2016/2019/SE**
Details: [Summary and Status of issues identified with September 2025 CU for SharePoint.](https://blog.stefan-gossner.com/2025/09/25/summary-and-status-of-issues-identified-with-september-2025-cu-for-sharepoint/)

**After installation of Septeber 2025 CU consider the following (WSS_WPG group - NT Authority\system)**
Details: [Trending Issue: SharePoint fixes fail to install after installation of September 2025 CU](https://blog.stefan-gossner.com/2025/09/11/trending-issue-sharepoint-fixes-fail-to-install-after-installation-of-september-2025-cu/)