### PR TITLE
June 2026 updates for SharePoint 2016/2019/SE (trending Issue) and OOS

### DIFF
--- a/Scripts/AutoSPSourceBuilder.xml
+++ b/Scripts/AutoSPSourceBuilder.xml
@@ -1654,6 +1654,8 @@
             <CumulativeUpdate Name="April 2026" Build="16.0.5548.1002" Url="https://download.microsoft.com/download/b67099e0-d863-4b83-b389-e458ae3191cd/wssloc2016-kb5002862-fullfile-x64-glb.exe" ExpandedFile="wssloc2016-kb5002862-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="May 2026" Build="16.0.5552.1002" Url="https://download.microsoft.com/download/5225772d-2845-4585-8d08-6524c51ac1fb/sts2016-kb5002868-fullfile-x64-glb.exe" ExpandedFile="sts2016-kb5002868-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="May 2026" Build="16.0.5552.1002" Url="https://download.microsoft.com/download/533d1a40-9c0b-4860-bad1-657be09eb076/wssloc2016-kb5002869-fullfile-x64-glb.exe" ExpandedFile="wssloc2016-kb5002869-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="June 2026" Build="16.0.5556.1005" Url="https://download.microsoft.com/download/84f097bf-ec16-4c80-a152-c2c74d12a363/sts2016-kb5002880-fullfile-x64-glb.exe" ExpandedFile="sts2016-kb5002880-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="June 2026" Build="16.0.5556.1005" Url="https://download.microsoft.com/download/c8c5134d-29ba-43d5-94cb-80a71c9f8f86/wssloc2016-kb5002881-fullfile-x64-glb.exe" ExpandedFile="wssloc2016-kb5002881-fullfile-x64-glb.exe" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="az-Latn-AZ" Url="https://download.microsoft.com/download/4/1/7/41789DDA-ABDD-45D2-AAB9-79025E69166B/serverlanguagepack.exe">
@@ -2303,6 +2305,8 @@
             <CumulativeUpdate Name="April 2026" Build="16.0.10417.20114" Url="https://download.microsoft.com/download/74e3080c-bf3e-4c71-adb8-c08f242937e1/wssloc2019-kb5002856-fullfile-x64-glb.exe" ExpandedFile="wssloc2019-kb5002856-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="May 2026" Build="16.0.10417.20128" Url="https://download.microsoft.com/download/6e1dceda-748c-4d03-af29-eac31733b7a2/sts2019-kb5002870-fullfile-x64-glb.exe" ExpandedFile="sts2019-kb5002870-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="May 2026" Build="16.0.10417.20128" Url="https://download.microsoft.com/download/6b6c86ba-98fd-4288-8e6b-d5c10a289108/wssloc2019-kb5002872-fullfile-x64-glb.exe" ExpandedFile="wssloc2019-kb5002872-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="June 2026" Build="16.0.10417.20153" Url="https://download.microsoft.com/download/931ff133-33eb-4e53-b30d-eec50c27fefb/sts2019-kb5002874-fullfile-x64-glb.exe" ExpandedFile="sts2019-kb5002874-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="June 2026" Build="16.0.10417.20153" Url="https://download.microsoft.com/download/6344c119-eca1-4f6e-9121-5872ece56e4e/wssloc2019-kb5002876-fullfile-x64-glb.exe" ExpandedFile="wssloc2019-kb5002876-fullfile-x64-glb.exe" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="az-Latn-AZ" Url="https://download.microsoft.com/download/D/6/4/D64A6203-2BB1-43AA-9EA6-365EE5A37E2F/serverlanguagepack.exe">
@@ -2586,6 +2590,7 @@
             <CumulativeUpdate Name="March 2026" Build="16.0.10417.20102" Url="https://download.microsoft.com/download/792ebbce-f380-4ffe-8ba7-332982a0ac44/wacserver2019-kb5002846-fullfile-x64-glb.exe" ExpandedFile="wacserver2019-kb5002846-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="April 2026" Build="16.0.10417.20113" Url="https://download.microsoft.com/download/184b769a-98f4-4bb1-ba09-98bf11bd9423/wacserver2019-kb5002855-fullfile-x64-glb.exe" ExpandedFile="wacserver2019-kb5002855-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="May 2026" Build="16.0.10417.20128" Url="https://download.microsoft.com/download/f7e624ca-8ab2-4acd-89bc-e8b53af001fa/wacserver2019-kb5002871-fullfile-x64-glb.exe" ExpandedFile="wacserver2019-kb5002871-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="June 2026" Build="16.0.10417.20137" Url="https://download.microsoft.com/download/b5df5c10-0312-4475-83c9-49b3abccdc16/wacserver2019-kb5002875-fullfile-x64-glb.exe" ExpandedFile="wacserver2019-kb5002875-fullfile-x64-glb.exe" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="az-Latn-AZ" Url="https://download.microsoft.com/download/A/0/3/A03B732F-512B-4D29-A2FD-49873FEA60C3/wacserverlanguagepack.exe">
@@ -2883,6 +2888,7 @@
             <CumulativeUpdate Name="March 2026" Build="16.0.19725.20076" Url="https://download.microsoft.com/download/9246c84a-1461-48be-8aee-6b99dc65f5cf/uber-subscription-kb5002843-fullfile-x64-glb.exe" ExpandedFile="uber-subscription-kb5002843-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="April 2026" Build="16.0.19725.20210" Url="https://download.microsoft.com/download/f839c57c-7b4e-4213-b03b-2c1508e13588/uber-subscription-kb5002853-fullfile-x64-glb.exe" ExpandedFile="uber-subscription-kb5002853-fullfile-x64-glb.exe" />
             <CumulativeUpdate Name="May 2026" Build="16.0.19725.20280" Url="https://download.microsoft.com/download/926a1266-38a6-4721-9cb8-700df61ffaa2/uber-subscription-kb5002863-fullfile-x64-glb.exe" ExpandedFile="uber-subscription-kb5002863-fullfile-x64-glb.exe" />
+            <CumulativeUpdate Name="June 2026" Build="16.0.19725.20384" Url="https://download.microsoft.com/download/7b4c3ae5-ce9d-4f5d-8e30-cefd28c92c3e/uber-subscription-kb5002873-fullfile-x64-glb.exe" ExpandedFile="uber-subscription-kb5002873-fullfile-x64-glb.exe" />
         </CumulativeUpdates>
         <LanguagePacks>
             <LanguagePack Name="ar-SA" Url="https://download.microsoft.com/download/d/e/7/de7aa90a-b01c-4123-84be-cdaf41a80bed/ServerLanguagePack.iso">


### PR DESCRIPTION
**Attention**
There's a trending issue with the June 2026 updates for SharePoint. SharePoint 2010–style workflows are failing after installing the June 2026 Cumulative Update (CU). This affects all supported SharePoint Versions (2016, 2019, SPSE).
According to the following link a fix for the workflow issue is planned to be released with July 2026 CU for all supported SharePoint Versions (2016, 2019, Subscription Edition)

Details see: [Trending Issue: SharePoint 2010 workflows fail after June 2026 CU](https://blog.stefan-gossner.com/2026/06/12/trending-issue-sharepoint-2010-workflows-fail-after-june-2026-cu/)